### PR TITLE
Add basic multiplayer click battle

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,13 @@
     </div>
     <div id="status" class="row" style="opacity:.9"></div>
   </div>
+  <div id="game" class="mpPanel" style="display:none">
+    <div class="title">Click Battle</div>
+    <div class="row">Ты: <b id="hostScore">0</b></div>
+    <div class="row">Соперник: <b id="userScore">0</b></div>
+    <button id="hostClick" class="btn primary">Клик!</button>
+    <div id="gameStatus" class="row" style="opacity:.9"></div>
+  </div>
   <div id="diag" class="diag"></div>
 <script>
 (()=>{
@@ -38,7 +45,10 @@
   let cloudIdx=0, code='-----', peer=null, conn=null, lossCount=0;
   const srvEl=document.getElementById('srv'), codeEl=document.getElementById('code'), players=document.getElementById('players'), status=document.getElementById('status');
   const startBtn=document.getElementById('start'), switchBtn=document.getElementById('switch'), regenBtn=document.getElementById('regen');
+  const hostPanel=document.getElementById('host'), gamePanel=document.getElementById('game');
+  const hostScoreEl=document.getElementById('hostScore'), userScoreEl=document.getElementById('userScore'), hostClick=document.getElementById('hostClick'), gameStatus=document.getElementById('gameStatus');
   const diag=document.getElementById('diag');
+  let score={host:0,user:0};
   function log(s){ diag.textContent=(diag.textContent+'\\n'+s).trim().slice(-2000) }
   function makeCode(){ return String(Math.floor(10000+Math.random()*90000)) }
   function roomId(c){ return 'hookarena-'+c }
@@ -54,7 +64,12 @@
     try{ peer?.destroy?.() }catch(_){}
     peer = new Peer(roomId(code), opts());
     peer.on('open', id=>{ status.textContent='Ожидание подключения...'; log('open@'+clouds[cloudIdx]+': '+id) });
-    peer.on('connection', c=>{ conn=c; players.textContent='admin (ты)\\nuser'; status.textContent='Игрок подключился.'; startBtn.disabled=false; c.on('close',()=>log('conn close')); c.on('error',e=>log('conn err '+e)) });
+    peer.on('connection', c=>{
+      conn=c; players.textContent='admin (ты)\nuser'; status.textContent='Игрок подключился.'; startBtn.disabled=false;
+      c.on('data',d=>{ if(d.type==='click'){ score.user++; updateScore(); conn.send({type:'score',score}); checkWin(); } });
+      c.on('close',()=>log('conn close'));
+      c.on('error',e=>log('conn err '+e));
+    });
     peer.on('error', e=>{ log('peer error '+e); status.textContent='Ошибка: '+e; onLost() });
     peer.on('disconnected', ()=>{ log('disconnected'); status.textContent='Потеряна связь с сервером, переподключение...'; onLost() });
     peer.on('close', ()=>{ log('close'); status.textContent='Соединение закрыто, переподключение...'; onLost() });
@@ -72,7 +87,27 @@
   }
   switchBtn.onclick=()=>{ cloudIdx=(cloudIdx+1)%clouds.length; onLost() };
   regenBtn.onclick=()=>{ code=makeCode(); startPeer() };
-  startBtn.onclick=()=>alert('MP стартовал (сеть ок).');
+  startBtn.onclick=()=>{
+    conn?.send({type:'start'});
+    startGame();
+    conn?.send({type:'score',score});
+  };
+  hostClick.onclick=()=>{
+    score.host++; updateScore(); conn?.send({type:'score',score}); checkWin();
+  };
+  function startGame(){
+    score={host:0,user:0}; updateScore();
+    hostPanel.style.display='none'; gamePanel.style.display='block'; hostClick.disabled=false;
+    gameStatus.textContent='Игра началась!';
+  }
+  function updateScore(){ hostScoreEl.textContent=score.host; userScoreEl.textContent=score.user; }
+  function checkWin(){
+    if(score.host>=10 || score.user>=10){
+      const win=score.host>score.user?'Ты победил!':'Соперник победил';
+      gameStatus.textContent=win; hostClick.disabled=true;
+      conn?.send({type:'end',score});
+    }
+  }
   mount();
 })();
 </script>

--- a/join.html
+++ b/join.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Hook Arena — Join</title>
+<style>
+  html,body{height:100%;margin:0;background:#0b0f17}
+  .mpPanel{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);background:#0b1220;border:1px solid #334155;border-radius:12px;padding:16px 18px;color:#e5e7eb;min-width:340px}
+  .title{font:18px/1.3 system-ui,sans-serif;margin-bottom:10px}
+  .row{margin:8px 0}
+  .btn{background:#1f2937;border:1px solid #334155;color:#e5e7eb;border-radius:10px;padding:8px 14px;cursor:pointer}
+  .btn.primary{background:#2563eb;border-color:#1d4ed8}
+  .diag{position:fixed;left:10px;bottom:10px;color:#9ca3af;font:12px/1.3 ui-monospace,monospace;max-width:80vw;white-space:pre-wrap}
+</style>
+<script src="https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js"></script>
+</head>
+<body>
+  <div id="join" class="mpPanel">
+    <div class="title">Присоединиться к игре</div>
+    <div class="row">Код комнаты: <input id="code" class="btn" style="width:80px;text-align:center"></div>
+    <div class="row">Сервер:
+      <select id="server" class="btn">
+        <option value="0.peerjs.com">0</option>
+        <option value="1.peerjs.com">1</option>
+        <option value="2.peerjs.com">2</option>
+      </select>
+    </div>
+    <div class="row"><button id="joinBtn" class="btn primary">Войти</button></div>
+    <div id="joinStatus" class="row" style="opacity:.9"></div>
+  </div>
+  <div id="game" class="mpPanel" style="display:none">
+    <div class="title">Click Battle</div>
+    <div class="row">Ты: <b id="userScore">0</b></div>
+    <div class="row">Соперник: <b id="hostScore">0</b></div>
+    <button id="userClick" class="btn primary">Клик!</button>
+    <div id="gameStatus" class="row" style="opacity:.9"></div>
+  </div>
+  <div id="diag" class="diag"></div>
+<script>
+(()=>{ 
+  const join=document.getElementById('join'), game=document.getElementById('game');
+  const codeInput=document.getElementById('code'), serverSel=document.getElementById('server'), joinBtn=document.getElementById('joinBtn'), joinStatus=document.getElementById('joinStatus');
+  const userScoreEl=document.getElementById('userScore'), hostScoreEl=document.getElementById('hostScore'), clickBtn=document.getElementById('userClick'), gameStatus=document.getElementById('gameStatus');
+  const diag=document.getElementById('diag');
+  let conn=null, score={host:0,user:0};
+  function log(s){ diag.textContent=(diag.textContent+'\n'+s).trim().slice(-2000) }
+  joinBtn.onclick=()=>{
+    const code=codeInput.value.trim();
+    if(!code){ joinStatus.textContent='Введите код'; return; }
+    joinStatus.textContent='Подключение...';
+    const peer=new Peer(null,{host:serverSel.value, port:443, secure:true, path:'/peerjs', debug:1});
+    peer.on('error', e=>{ joinStatus.textContent='Ошибка: '+e; log('peer err '+e); });
+    peer.on('open', id=>{
+      conn=peer.connect('hookarena-'+code);
+      conn.on('open', ()=>{ join.style.display='none'; game.style.display='block'; gameStatus.textContent='Ожидание старта...'; });
+      conn.on('data', d=>{
+        if(d.type==='start'){ gameStatus.textContent='Игра началась!'; }
+        else if(d.type==='score'){ score=d.score; update(); }
+        else if(d.type==='end'){ score=d.score; update(); gameStatus.textContent=d.score.host>=10?'Соперник победил':'Ты победил!'; clickBtn.disabled=true; }
+      });
+      conn.on('close', ()=>log('conn close'));
+      conn.on('error', e=>log('conn err '+e));
+    });
+  };
+  clickBtn.onclick=()=>{ conn?.send({type:'click'}); };
+  function update(){ userScoreEl.textContent=score.user; hostScoreEl.textContent=score.host; }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Turn lobby into a simple "Click Battle" with score tracking and win detection
- Handle player messages and score sync over PeerJS
- Add join page so second player can enter code and play

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a96daf60832e971ce86515bc89f3